### PR TITLE
Explicitly define depedency versions

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,7 @@
+Copyright (C) 2012 Nicolas Viennot
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Installation
 gem 'nobrainer'
 ```
 
-Usage Example
---------------
+Usage
+------
 
 Here is a quick example of what NoBrainer can do:
 
 ```ruby
-#!/usr/bin/env ruby
 require 'nobrainer'
 
 NoBrainer.connect 'rethinkdb://localhost/blog'
 
 class Post
   include NoBrainer::Document
+
   field :title
   field :body
 
@@ -33,6 +33,7 @@ end
 
 class Comment
   include NoBrainer::Document
+  
   field :author
   field :body
 
@@ -64,20 +65,20 @@ puts post.comments.count == 1
 Features
 ---------
 
-* Autogeneration of ID MongoDB style
-* creation of database and tables on demand
-* find/create/save/update_attributes/destroy. XXX find vs find!
-* attributes accessors
-* validation support, expected behavior with save!, save, etc (todo: uniqueness validation)
-* validatation, create, update, save, destroy callbacks
-* where, order_by, skip, limit, each
-* update, inc, dec
-* belongs_to, has_many
-* to_json, to_xml
-* attr_protected.
-* rails3 compatible
+* Compatible with Rails 3
+* Autogeneration of ID, MongoDB style
+* Creation of database and tables on demand
+* Attributes accessors (`attr_accessor`)
+* Validation support, expected behavior with `save!`, `save`, etc. (uniqueness validation still in development)
+* Validatation with create, update, save, and destroy callbacks.
+* `find`, `create`, `save`, `update_attributes`, `destroy` (`*.find` vs. `find!`).
+* `where`, `order_by`, `skip`, `limit`, `each`
+* `update`, `inc`, `dec`
+* `belongs_to`, `has_many`
+* `to_json`, `to_xml`
+* `attr_protected`
 
 License
 --------
 
-MIT License
+See [`LICENSE.md`](https://github.com/nviennot/nobrainer/blob/master/LICENSE.md).

--- a/nobrainer.gemspec
+++ b/nobrainer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rethinkdb", "~> 1.2.6.0"
   s.add_dependency "activemodel", "~> 3.2.9"
 
-  s.files        = Dir["lib/**/*"] + ['README.md']
+  s.files        = Dir["lib/**/*"] + ['README.md'] + ['LICENSE.md']
   s.require_path = 'lib'
   s.has_rdoc     = false
 end


### PR DESCRIPTION
I explicitly defined the versions of `rethinkdb` and `active_model` in the `.gemspec` to avoid any unforeseen issues with Bundler updates. I also made the README a little more readable.

Thank you for making this Gem!
