### PR TITLE
Many-to-many relation support

### DIFF
--- a/lib/no_brainer/document/selection.rb
+++ b/lib/no_brainer/document/selection.rb
@@ -27,7 +27,7 @@ module NoBrainer::Document::Selection
       end
     end
 
-    delegate :count, :where, :order_by, :first, :last, :to => :all
+    delegate :eq_join, :map, :pluck, :count, :where, :order_by, :first, :last, :to => :all
 
     def selector_for(id)
       # TODO Pass primary key if not default

--- a/lib/no_brainer/relation/has_many.rb
+++ b/lib/no_brainer/relation/has_many.rb
@@ -7,6 +7,15 @@ class NoBrainer::Relation::HasMany < Struct.new(:parent_klass, :children_name, :
     @foreign_key ||= options[:foreign_key] || :"#{parent_klass.name.underscore}_id"
   end
 
+  def children_foreign_key
+    # TODO test :child_foreign_key
+    @children_foreign_key ||= :"#{children_klass.name.underscore}_id"
+  end
+
+  def through_klass
+    @through_klass ||= options[:through].to_s.singularize.camelize.constantize if options[:through]
+  end
+
   def children_klass
     # TODO test :class_name
     @children_klass ||= (options[:class_name] || children_name.to_s.singularize.camelize).constantize
@@ -20,10 +29,10 @@ class NoBrainer::Relation::HasMany < Struct.new(:parent_klass, :children_name, :
         new_children.each { |child| #{children_name} << child }
       end
 
-      def #{children_name}
+      def #{children_name}(conditions = {})
         # TODO Cache array
         relation = self.class.relations[:#{children_name}]
-        ::NoBrainer::Relation::HasMany::Selection.new(self, relation)
+        ::NoBrainer::Relation::HasMany::Selection.new(self, relation, conditions)
       end
     RUBY
   end

--- a/lib/no_brainer/relation/has_many/selection.rb
+++ b/lib/no_brainer/relation/has_many/selection.rb
@@ -1,27 +1,57 @@
 class NoBrainer::Relation::HasMany::Selection < NoBrainer::Selection
-  attr_accessor :parent_instance, :relation
-  delegate :foreign_key, :children_klass, :to => :relation
+  attr_accessor :parent_instance, :relation, :conditions
+  delegate :children_foreign_key, :through_klass, :foreign_key, :children_klass, :to => :relation
 
-  def initialize(parent_instance, relation)
+  def initialize(parent_instance, relation, conditions = {})
     self.relation = relation
     self.parent_instance = parent_instance
-    super children_klass.where(foreign_key => parent_instance.id)
+    self.conditions = conditions
+
+    if through_klass
+      query = through_klass.where(conditions.merge({foreign_key => parent_instance.id})).eq_join(children_foreign_key, children_klass.table).map { |r| r[:right]}
+      query.context =  {:klass => children_klass}
+      super query
+    else
+      super children_klass.where(foreign_key => parent_instance.id)
+    end
   end
 
   def <<(child)
     # TODO raise when child doesn't have the proper type
-    child.update_attributes(foreign_key => parent_instance.id)
+    if through_klass
+      through_klass.create(conditions.merge({foreign_key => parent_instance.id, children_foreign_key => child.id}))
+    else
+      child.update_attributes(foreign_key => parent_instance.id)
+    end
   end
 
   def build(attrs={})
-    children_klass.new(attrs.merge(foreign_key => parent_instance.id))
+    if through_klass
+      children_klass.new(attrs)
+    else
+      children_klass.new(attrs.merge(foreign_key => parent_instance.id))
+    end
   end
 
   def create(*args)
-    build(*args).tap { |doc| doc.save }
+    if through_klass
+      build(*args).tap do |doc|
+        doc.save
+        through_klass.create(conditions.merge({foreign_key => parent_instance.id, children_foreign_key => doc.id}))
+      end
+    else
+      build(*args).tap { |doc| doc.save }
+    end
   end
 
   def create!(*args)
-    build(*args).tap { |doc| doc.save! }
+    if through_klass
+      build(*args).tap do |doc|
+        doc.save!
+        through_klass.create!(conditions.merge({foreign_key => parent_instance.id, children_foreign_key => doc.id}))
+      end 
+    else
+      build(*args).tap { |doc| doc.save! }
+    end
   end
 end

--- a/lib/no_brainer/selection.rb
+++ b/lib/no_brainer/selection.rb
@@ -2,5 +2,5 @@ class NoBrainer::Selection
   extend NoBrainer::Autoload
 
   autoload_and_include :Core, :Count, :Delete, :Enumerable, :First, :Inc,
-                       :Limit, :OrderBy, :Scope, :Update, :Where
+                       :Limit, :OrderBy, :Scope, :Update, :Where, :Pluck, :Map, :EqJoin
 end

--- a/lib/no_brainer/selection/core.rb
+++ b/lib/no_brainer/selection/core.rb
@@ -10,6 +10,7 @@ module NoBrainer::Selection::Core
     # We are saving klass as a context
     # so that the table_on_demand middleware can do its job
     # TODO FIXME Sadly it gets funny with associations
+
     if query_or_selection.is_a? NoBrainer::Selection
       selection = query_or_selection
       self.query = selection.query

--- a/lib/no_brainer/selection/eq_join.rb
+++ b/lib/no_brainer/selection/eq_join.rb
@@ -1,0 +1,6 @@
+module NoBrainer::Selection::EqJoin
+  def eq_join(*args, &block)
+    chain query.eq_join(*args, &block)
+  end
+
+end

--- a/lib/no_brainer/selection/map.rb
+++ b/lib/no_brainer/selection/map.rb
@@ -1,0 +1,5 @@
+module NoBrainer::Selection::Map
+  def map(&block)
+    chain query.map(&block)
+  end
+end

--- a/lib/no_brainer/selection/pluck.rb
+++ b/lib/no_brainer/selection/pluck.rb
@@ -1,0 +1,5 @@
+module NoBrainer::Selection::Pluck
+  def pluck(*args)
+    chain(query.pluck(*args)).run
+  end
+end


### PR DESCRIPTION
Example usage:

``` ruby
class Link
  include NoBrainer::Document
  field :url
  belongs_to :comment
end


class Comment
  include NoBrainer::Document

  field :body
  has_many :posts, through: 'comments_posts'

  has_many :links
end

class Post
  include NoBrainer::Document

  field :title
  field :content
  field :author

  has_many :comments, through: 'comments_posts'
end


class CommentsPost
  include NoBrainer::Document

  belongs_to :comment
  belongs_to :post

  field :category
end

p = Post.create(title: 'Test Article', content: 'Text Text Text Text Text', author: 'Alex')
p.comments(category: 'Art').create(body: 'Text Text Text Text Text')
p.comments(category: 'Internet').create(body: 'Text Text Text Text Text')


# Print comments from 'Art' category
puts p.comments(category: 'Art').to_a.inspect

# Print comments from 'Internet' category
puts p.comments(category: 'Internet').to_a.inspect

# Print all comments
puts p.comments.to_a.inspect
```
