### PR TITLE
Uniqueness validations failing with persisted documents

### DIFF
--- a/lib/no_brainer/document/validation.rb
+++ b/lib/no_brainer/document/validation.rb
@@ -39,14 +39,24 @@ module NoBrainer::Document::Validation
     # @return [ Boolean ] true if the attribute is unique.
     def validate_each(document, attribute, value)
       finder = document.class.where(attribute => value)
-      if document.persisted?
-        finder = finder.where{|doc| doc["id"].ne(document.id)}
-      end
+      finder = apply_scopes(finder, document)
+      finder = exclude_document(finder, document) if document.persisted?
       is_unique = finder.count == 0
       unless is_unique
         document.errors.add(attribute, 'is already taken')
       end
       is_unique
+    end
+
+    def apply_scopes(finder, document)
+      Array.wrap(options[:scope]).each do |scope_item|
+        finder = finder.where{|doc| doc[scope_item.to_s].eq(document.attributes[scope_item.to_s])}
+      end
+      finder
+    end
+
+    def exclude_document(finder, document)
+      finder.where{|doc| doc["id"].ne(document.attributes["id"])}
     end
   end
 end

--- a/spec/integration/serialization_spec.rb
+++ b/spec/integration/serialization_spec.rb
@@ -8,7 +8,7 @@ describe "NoBrainer serialization" do
 
   it 'serializes to json' do
     JSON::parse(doc.to_json).should ==
-      {'id' => doc.id, 'field1' => 'hello', 'field2' => nil}
+      {'id' => doc.id, 'field1' => 'hello', 'field2' => nil, 'field3' => nil}
   end
 
   it 'serializes to xml' do

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -5,6 +5,7 @@ module ModelsHelper
 
       field :field1
       field :field2
+      field :field3
     end
   end
 


### PR DESCRIPTION
Ran into an issue using uniqueness validations:

``` ruby
class Document
  include NoBrainer::Document
  validates :handle, uniqueness: true
end
```

``` ruby
> document = Document.create!(handle: 'my-handle')
 => #<Document id: "529db25a73afb09a5700000a", created_at: 2013-12-03 10:28:42 +0000, updated_at: 2013-12-03 10:28:42 +0000, handle: "my-handle">

> document.valid?
 => false

> document.errors
 => #<ActiveModel::Errors:0x007f84e9a37558 @base=#<Document id: "529db25a73afb09a5700000a", created_at: 2013-12-03 10:28:42 +0000, updated_at: 2013-12-03 10:28:42 +0000, handle: "my-handle">, @messages={:handle=>["is already taken"]}> 
```

The attached pull request excludes the current document's `id` from the uniqueness validation query if it has already been persisted.

I've also added support for :scope:

``` ruby
class Document
  include NoBrainer::Document
  validates :handle, uniqueness: {scope: :account_id}
end
```

and also multiple scopes per attribute:

``` ruby
class Document
  include NoBrainer::Document
  validates :handle, uniqueness: {scope: [:account_id, :user_id]}
end
```
