### PR TITLE
Reload returns the appropriate object, not an attributes hash

### DIFF
--- a/lib/no_brainer/document/persistance.rb
+++ b/lib/no_brainer/document/persistance.rb
@@ -35,6 +35,7 @@ module NoBrainer::Document::Persistance
 
   def reload
     assign_attributes(selector.run, :prestine => true)
+    self
   end
 
   def update(&block)

--- a/spec/integration/persistance_spec.rb
+++ b/spec/integration/persistance_spec.rb
@@ -46,6 +46,12 @@ describe 'NoBrainer persistance' do
     SimpleDocument.find(doc.id).should == nil
   end
 
+  it 'reloads' do
+    doc.field2 = 'brave world'
+    doc.reload.should be_kind_of(SimpleDocument)
+    doc.field2.should == 'world'
+  end
+
   it 'destroys' do
     doc.destroy.should == true
     SimpleDocument.find(doc.id).should == nil


### PR DESCRIPTION
To be more consistent with ActiveRecord and Mongoid, I think #reload should return the model object rather than the hash of attributes.
