### PR TITLE
added timing to logger

### DIFF
--- a/lib/no_brainer/query_runner/logger.rb
+++ b/lib/no_brainer/query_runner/logger.rb
@@ -1,8 +1,11 @@
 class NoBrainer::QueryRunner::Logger < NoBrainer::QueryRunner::Middleware
   def call(env)
+    start_time = Time.now
     res = @runner.call(env)
     if NoBrainer.logger and NoBrainer.logger.level <= Logger::DEBUG
-      NoBrainer.logger.debug env[:query].inspect.gsub("\n", '')
+      stop_time = Time.now
+      dt = (stop_time - start_time) * 1000.0
+      NoBrainer.logger.debug "#{env[:query].inspect.gsub("\n", '')}  [#{dt} ms]"
     end
     res
   end


### PR DESCRIPTION
Added execution time in milleseconds. I'm not really sure what `"[#{options}]" if options.present?` is supposed to be. In what scope is `options` defined?
