### PR TITLE
added 'type' to allowed field options

### DIFF
--- a/lib/no_brainer/document/attributes.rb
+++ b/lib/no_brainer/document/attributes.rb
@@ -81,7 +81,7 @@ module NoBrainer::Document::Attributes
     def field(name, options={})
       name = name.to_sym
 
-      options.assert_valid_keys(:index, :default)
+      options.assert_valid_keys(:index, :default, :type)
       if name.in? NoBrainer::Criteria::Chainable::Where::RESERVED_FIELDS
         raise "Cannot use a reserved field name: #{name}"
       end


### PR DESCRIPTION
I'm fine with how NoBrainer currently handles field types automatically, but I'd like the ability to explicitly annotate the types of my fields. I'm using this type information for my own serialization purposes, but I figured it would one day end up being used by NoBrainer anyway. 
