### PR TITLE
Fixed deprecated callback termniator warning

### DIFF
--- a/lib/no_brainer/document/callbacks.rb
+++ b/lib/no_brainer/document/callbacks.rb
@@ -1,10 +1,19 @@
 module NoBrainer::Document::Callbacks
   extend ActiveSupport::Concern
 
+  def self.terminator
+    if Gem.loaded_specs['activesupport'].version >= Gem::Version.new('4.1')
+      lambda { false }
+    else
+      'false'
+    end
+  end
+
   included do
     extend ActiveModel::Callbacks
-    define_model_callbacks :initialize, :create, :update, :save, :destroy, :terminator => 'false'
-    define_model_callbacks :find, :only => [:after], :terminator => 'false'
+
+    define_model_callbacks :initialize, :create, :update, :save, :destroy, :terminator => NoBrainer::Document::Callbacks.terminator
+    define_model_callbacks :find, :only => [:after], :terminator => NoBrainer::Document::Callbacks.terminator
   end
 
   def initialize(*args, &block)

--- a/lib/no_brainer/document/persistance.rb
+++ b/lib/no_brainer/document/persistance.rb
@@ -1,11 +1,6 @@
 module NoBrainer::Document::Persistance
   extend ActiveSupport::Concern
 
-  included do
-    extend ActiveModel::Callbacks
-    define_model_callbacks :create, :update, :save, :destroy, :terminator => 'false'
-  end
-
   def _initialize(attrs={}, options={})
     @new_record = !options[:from_db]
     super


### PR DESCRIPTION
Rails 4.1 and above deprecates string style callback terminators. This switches off the version to provide either a lambda or a string, keeping backward compatibility.
