### PR TITLE
Include table name information to missing index exception

### DIFF
--- a/lib/no_brainer/query_runner/missing_index.rb
+++ b/lib/no_brainer/query_runner/missing_index.rb
@@ -2,8 +2,13 @@ class NoBrainer::QueryRunner::MissingIndex < NoBrainer::QueryRunner::Middleware
   def call(env)
     @runner.call(env)
   rescue RethinkDB::RqlRuntimeError => e
-    if e.message =~ /^Index `(.+)` was not found\.$/
-      raise NoBrainer::Error::MissingIndex.new("Please run \"rake db:update_indexes\" to create the index `#{$1}`\n" +
+
+    index_data = e.message.match /^Index `(?<name>.+)` was not found\.$/
+    table_data = e.message.match /table\(\"(?<name>\S+)\"\)/
+
+    if index_data[:name] && table_data[:name]
+      raise NoBrainer::Error::MissingIndex.new("Please run \"rake db:update_indexes\" to create the index `#{index_data[:name]}` " +
+                                               "in the table `#{table_data[:name]}`\n" +
                                                "--> Read http://nobrainer.io/docs/indexes for more information.")
     end
     raise


### PR DESCRIPTION
Sometimes it can be too difficult to figure it out which table needs adding an index, so I suggest to add a table name to exception message so developers can easily figure it out what's going on.

Screenshot:
![action controller_ exception caught-1](https://cloud.githubusercontent.com/assets/482566/2645981/8deaf87a-bf38-11e3-8cb9-dcc25300feec.png)
