### PR TITLE
Don't require dirty tracking in ActiveModel patch

### DIFF
--- a/lib/no_brainer/document/validation.rb
+++ b/lib/no_brainer/document/validation.rb
@@ -43,6 +43,7 @@ end
 
 class ActiveModel::EachValidator
   def should_validate_field?(record, attribute)
+    return true unless record.is_a?(NoBrainer::Document)
     record.new_record? || record.__send__("#{attribute}_changed?")
   end
 


### PR DESCRIPTION
Some ActiveModels may not support dirty tracking, so default to always validating.