### PR TITLE
store_in: stringify names to fix auto-creation

### DIFF
--- a/lib/no_brainer/document/store_in.rb
+++ b/lib/no_brainer/document/store_in.rb
@@ -16,13 +16,13 @@ module NoBrainer::Document::StoreIn
 
     def database_name
       db = self.store_in_options[:database]
-      db.is_a?(Proc) ? db.call : db
+      (db.is_a?(Proc) ? db.call : db).try(:to_s)
     end
 
     def table_name
       table = store_in_options[:table]
       table_name = table.is_a?(Proc) ? table.call : table
-      table_name || root_class.name.tableize.gsub('/', '__')
+      table_name.try(:to_s) || root_class.name.tableize.gsub('/', '__')
     end
 
     def rql_table

--- a/spec/integration/store_in_spec.rb
+++ b/spec/integration/store_in_spec.rb
@@ -87,6 +87,20 @@ describe 'NoBrainer store_in' do
     end
   end
 
+  context 'when using store_in with symbols' do
+    it 'converts names to strings' do
+      SimpleDocument.store_in :database => :test_db1, :table => :table1
+      SimpleDocument.table_name.should == 'table1'
+      SimpleDocument.database_name.should == 'test_db1'
+    end
+
+    it 'converts lambda names to strings' do
+      SimpleDocument.store_in :database => ->{ :test_db1} , :table => ->{ :table1 }
+      SimpleDocument.table_name.should == 'table1'
+      SimpleDocument.database_name.should == 'test_db1'
+    end
+  end
+
   context 'when using store_in and with_databases' do
     before do
       SimpleDocument.store_in :database => ->{ @database }


### PR DESCRIPTION
The `store_in` feature mostly works fine with symbols now, but it breaks
auto-creation of tables and databases.