### PR TITLE
Specs for association options (and bug fixes) and Model.find(multiple pks)

### DIFF
--- a/lib/no_brainer/criteria/find.rb
+++ b/lib/no_brainer/criteria/find.rb
@@ -10,12 +10,44 @@ module NoBrainer::Criteria::Find
   end
   alias_method :find_by!, :find_by
 
-  def find?(pk)
-    without_ordering.find_by?(model.pk_name => pk)
+  def find?(*pks)
+    expects_array = pks.first.kind_of?(Array)
+    return pks.first if expects_array && pks.first.empty?
+    
+    pks = pks.flatten.compact.uniq
+    
+    case pks.size
+    when 0
+      nil
+    when 1
+      doc = without_ordering.find_by?(model.pk_name => pks.first)
+      expects_array ? [ doc ] : doc
+    else
+      find_some(pks)
+    end
   end
 
-  def find(pk)
-    without_ordering.find_by(model.pk_name => pk)
+  def find(*pks)
+    expects_array = pks.first.kind_of?(Array)
+    return pks.first if expects_array && pks.first.empty?
+    
+    pks = pks.flatten.compact.uniq
+    
+    case pks.size
+    when 0
+      raise_not_found(pks)
+    when 1
+      doc = without_ordering.find_by(model.pk_name => pks.first)
+      expects_array ? [ doc ] : doc
+    else
+      docs = find_some(pks)
+      if docs.count == pks.size
+       docs
+      else
+       missing_pks = pks - docs.map(&:pk_value)
+       raise_not_found([model.pk_name => missing_pks.join(', ')])
+      end
+    end
   end
   alias_method :find!, :find
 
@@ -23,5 +55,9 @@ module NoBrainer::Criteria::Find
 
   def raise_not_found(args)
     raise NoBrainer::Error::DocumentNotFound, "#{model} #{args.inspect.gsub(/\[{(.*)}\]/, '\1')} not found"
+  end
+  
+  def find_some(pks)
+    without_ordering.where({:or => pks.map {|pk| {model.pk_name => pk} } })
   end
 end

--- a/lib/no_brainer/document/association/belongs_to.rb
+++ b/lib/no_brainer/document/association/belongs_to.rb
@@ -7,17 +7,14 @@ class NoBrainer::Document::Association::BelongsTo
     extend NoBrainer::Document::Association::EagerLoader::Generic
 
     def foreign_key
-      # TODO test :foreign_key
       options[:foreign_key].try(:to_sym) || :"#{target_name}_#{primary_key}"
     end
 
     def primary_key
-      # TODO test :primary_key
       options[:primary_key].try(:to_sym) || target_model.pk_name
     end
 
     def target_model
-      # TODO test :class_name
       (options[:class_name] || target_name.to_s.camelize).constantize
     end
 
@@ -64,7 +61,7 @@ class NoBrainer::Document::Association::BelongsTo
 
   def write(target)
     assert_target_type(target)
-    owner.write_attribute(foreign_key, target.try(:pk_value))
+    owner.write_attribute(foreign_key, target.try(primary_key))
     preload(target)
   end
 

--- a/lib/no_brainer/document/association/has_many.rb
+++ b/lib/no_brainer/document/association/has_many.rb
@@ -7,17 +7,14 @@ class NoBrainer::Document::Association::HasMany
     extend NoBrainer::Document::Association::EagerLoader::Generic
 
     def foreign_key
-      # TODO test :foreign_key
-      options[:foreign_key].try(:to_sym) || :"#{owner_model.name.underscore}_#{owner_model.pk_name}"
+      options[:foreign_key].try(:to_sym) || :"#{owner_model.name.underscore}_#{primary_key}"
     end
-
+    
     def primary_key
-      # TODO test :primary_key
       options[:primary_key].try(:to_sym) || target_model.pk_name
     end
 
     def target_model
-      # TODO test :class_name
       (options[:class_name] || target_name.to_s.singularize.camelize).constantize
     end
 
@@ -60,10 +57,10 @@ class NoBrainer::Document::Association::HasMany
   end
 
   def target_criteria
-    @target_criteria ||= base_criteria.where(foreign_key => owner.pk_value)
+    @target_criteria ||= base_criteria.where(foreign_key => owner.try(primary_key))
                                       .after_find(set_inverse_proc)
   end
-
+  
   def read
     target_criteria
   end

--- a/spec/integration/associations/belongs_to_spec.rb
+++ b/spec/integration/associations/belongs_to_spec.rb
@@ -79,4 +79,24 @@ describe 'belongs_to' do
       expect { Comment.create(:post => Comment.new) }.to raise_error NoBrainer::Error::InvalidType
     end
   end
+  
+  context 'when the association is set with a different primary_key' do
+    let(:columnist) { Columnist.create(:employee_id => 4500) }
+    let(:article)   { Article.create(:columnist_employee_id => columnist.employee_id) }
+    
+    it 'returns the object' do
+      article.columnist.should == columnist
+      article.columnist_employee_id.should == 4500
+    end
+  end
+  
+  context 'when the association is set with a different foreign_key' do
+    let(:article) { Article.create(:slug => 'shortened-slugged-title') }
+    let(:note)    { Footnote.create(:article_slug_url => article.slug) }
+    
+    it 'returns the object' do
+      note.article.should == article
+      note.article_slug_url.should == 'shortened-slugged-title'
+    end
+  end
 end

--- a/spec/integration/associations/has_many_spec.rb
+++ b/spec/integration/associations/has_many_spec.rb
@@ -51,4 +51,37 @@ describe 'has_many' do
       post.comments.map(&:body).should == [2,3,4]
     end
   end
+  
+  context 'when primary_key is set' do
+    let(:columnist) { Columnist.create(:employee_id => 9000) }
+    let(:article)   { Article.create(:columnist => columnist) }
+    
+    it 'responds to and sets the target foreign key' do
+      expect(article).to respond_to(:columnist_employee_id)
+      expect(article).to respond_to(:columnist)
+      expect(article.columnist_employee_id).to be == columnist.employee_id
+      expect(article.columnist).to be == columnist
+    end
+  end
+  
+  context 'when class_name is set' do
+    let(:article) { Article.create(slug: 'short-titled-article') }
+    let!(:footnotes) { 2.times.map { |i| Footnote.create(:body => i, :article => article) } }
+    
+    it 'responds to and sets the target class' do
+      expect(article).to respond_to(:notes)
+      article.notes.to_a.should =~ footnotes
+    end
+
+    it 'responds to and sets the foreign key' do
+      footnote = footnotes.first
+      expect(footnote).to respond_to(:article_slug_url)
+      expect(footnote).to respond_to(:article)
+      expect(footnote.article_slug_url).to be == article.slug
+      expect(footnote.article).to be == article
+      expect(article).to respond_to(:notes)
+      expect(article.notes.first).to be_a(Footnote) 
+    end
+  end
+  
 end

--- a/spec/support/models.rb
+++ b/spec/support/models.rb
@@ -36,6 +36,34 @@ module ModelsHelper
 
       belongs_to :post
     end
+    
+    define_class :Columnist do
+      include NoBrainer::Document
+
+      field :last_name
+      field :employee_id
+
+      has_many :articles, primary_key: :employee_id
+    end
+
+    define_class :Article do
+      include NoBrainer::Document
+
+      field :title
+      field :slug
+      field :body
+
+      belongs_to :columnist, primary_key: :employee_id
+      has_many :notes, class_name: 'Footnote', foreign_key: :article_slug_url, primary_key: :slug
+    end
+
+    define_class :Footnote do
+      include NoBrainer::Document
+
+      field :body
+
+      belongs_to :article, foreign_key: :article_slug_url, primary_key: :slug
+    end
   end
 
   def load_polymorphic_models


### PR DESCRIPTION
Sorry both these commits are in one pull request, it's my first time with git in a team environment.

I was converting over a Rails app to use rethinkdb and the belongs_to/has_many association options were not working as I expected.  I think I fixed where the problems were and wrote tests to support.

After that I tried to pass an array to Model.find() and tracked down where that failed.  I used the AR find method as a example for all the cases.

Also it's my first time using rspec, so if the syntax isn't right or something please send me on the right path.