### PR TITLE
Fixed active_model load error

### DIFF
--- a/lib/nobrainer.rb
+++ b/lib/nobrainer.rb
@@ -1,5 +1,6 @@
 require 'set'
 require 'active_support'
+require 'active_model'
 require 'thread'
 %w(module/delegation module/attribute_accessors module/introspection
    class/attribute object/blank object/inclusion object/deep_dup


### PR DESCRIPTION
Hi there!

I ran into a problem with this gem and tracked it down to a load error.
Basically `no_brainer/criteria/where` is trying to include ActiveModel which hasn't previously been required. To eleviate this problem I simply added `require 'active_model'` to `nobrainer.rb`.
Below is a more detailed explanation of the problem I was experiancing.

---

Basically if you set this in you `development.rb`
```ruby
config.cache_classes = true
config.eager_load = true
```

This error will be thrown every time you try to start the server
```
rails s
=> Booting Puma
=> Rails 4.2.1 application starting in development on http://localhost:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
Exiting
/Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/criteria/where.rb:11:in `<module:Where>': uninitialized constant NoBrainer::Criteria::Where::ActiveModel (NameError)
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/criteria/where.rb:1:in `<top (required)>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/autoload.rb:18:in `const_get'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/autoload.rb:18:in `block in autoload_and_include'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/autoload.rb:18:in `each'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/autoload.rb:18:in `autoload_and_include'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/criteria.rb:5:in `<class:Criteria>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/nobrainer-0.23.0/lib/no_brainer/criteria.rb:3:in `<top (required)>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/dependencies/autoload.rb:70:in `block in eager_load!'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/dependencies/autoload.rb:70:in `each_value'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/activesupport-4.2.1/lib/active_support/dependencies/autoload.rb:70:in `eager_load!'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/application/finisher.rb:56:in `each'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/application/finisher.rb:56:in `block in <module:Finisher>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/initializable.rb:30:in `instance_exec'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/initializable.rb:30:in `run'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/initializable.rb:55:in `block in run_initializers'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:226:in `block in tsort_each'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:348:in `block (2 levels) in each_strongly_connected_component'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:429:in `each_strongly_connected_component_from'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:347:in `block in each_strongly_connected_component'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `each'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `call'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:345:in `each_strongly_connected_component'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:224:in `tsort_each'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/tsort.rb:203:in `tsort_each'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/initializable.rb:54:in `run_initializers'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/application.rb:352:in `initialize!'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/config/environment.rb:5:in `<top (required)>'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/config.ru:3:in `require'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/config.ru:3:in `block in <main>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/builder.rb:55:in `instance_eval'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/builder.rb:55:in `initialize'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/config.ru:in `new'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/config.ru:in `<main>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/builder.rb:49:in `eval'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/builder.rb:49:in `new_from_string'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/builder.rb:40:in `parse_file'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/server.rb:299:in `build_app_and_options_from_config'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/server.rb:208:in `app'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands/server.rb:61:in `app'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/server.rb:336:in `wrapped_app'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands/server.rb:139:in `log_to_stdout'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands/server.rb:78:in `start'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands/commands_tasks.rb:80:in `block in server'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands/commands_tasks.rb:75:in `tap'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands/commands_tasks.rb:75:in `server'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands/commands_tasks.rb:39:in `run_command!'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/railties-4.2.1/lib/rails/commands.rb:17:in `<top (required)>'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/bin/rails:8:in `require'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/bin/rails:8:in `<top (required)>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/spring-1.3.5/lib/spring/client/rails.rb:28:in `load'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/spring-1.3.5/lib/spring/client/rails.rb:28:in `call'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/spring-1.3.5/lib/spring/client/command.rb:7:in `call'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/spring-1.3.5/lib/spring/client.rb:26:in `run'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/spring-1.3.5/bin/spring:48:in `<top (required)>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/spring-1.3.5/lib/spring/binstub.rb:11:in `load'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/gems/2.2.0/gems/spring-1.3.5/lib/spring/binstub.rb:11:in `<top (required)>'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/Stanko/.rbenv/versions/2.2.1/lib/ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /Users/Stanko/Documents/Ruby/Rails/Private/retking-react-test/bin/spring:13:in `<top (required)>'
	from bin/rails:3:in `load'
	from bin/rails:3:in `<main>'
```