### PR TITLE
Add compatibility with ActiveModel::Dirty#attribute_will_change!

### DIFF
--- a/lib/no_brainer/document/dirty.rb
+++ b/lib/no_brainer/document/dirty.rb
@@ -60,6 +60,7 @@ module NoBrainer::Document::Dirty
       @_old_attributes[attr] = current_value.deep_dup
     end
   end
+  alias_method :attribute_will_change!, :attribute_may_change
 
   def _read_attribute(name)
     super.tap do |value|


### PR DESCRIPTION
Callers use #attribute_will_change! to store the previous value of an attribute, before it is changed.