### PR TITLE
Fix Rails 5 deprecation

### DIFF
--- a/lib/no_brainer/railtie.rb
+++ b/lib/no_brainer/railtie.rb
@@ -26,7 +26,7 @@ class NoBrainer::Railtie < Rails::Railtie
   config.after_initialize do
     NoBrainer::Config.configure unless NoBrainer::Config.configured?
 
-    ActionDispatch::Reloader.to_prepare do
+    (NoBrainer.rails5? ? ActiveSupport::Reloader : ActionDispatch::Reloader).to_prepare do
       NoBrainer::Loader.cleanup
     end
   end


### PR DESCRIPTION
Using ActiveSupport::Reloader instead of ActionDispatch::Reloader to be
ready when Rails 5 hits (and to prevent it from breaking when 5.1 comes
out).

```
DEPRECATION WARNING: to_prepare is deprecated and will be removed from Rails 5.1
(use ActiveSupport::Reloader.to_prepare instead) (called from block in <class:Railtie> at /path/to/lib/no_brainer/railtie.rb:29)
```