### PR TITLE
Allow indexes whose rql_functions are  >255 characters

### DIFF
--- a/lib/no_brainer/document/index/meta_store.rb
+++ b/lib/no_brainer/document/index/meta_store.rb
@@ -10,7 +10,7 @@ class NoBrainer::Document::Index::MetaStore
 
   field :table_name,   :type => String, :required => true
   field :index_name,   :type => String, :required => true
-  field :rql_function, :type => String, :required => true
+  field :rql_function, :type => Text,   :required => true
 
   def rql_function=(value)
     super(JSON.dump(value))


### PR DESCRIPTION
Saving the Index Metadata silently fails when the rql_function is >255 characters causing those indexes to rebuilt each time `.sync_indexes` is called.   

