### PR TITLE
Fix for Rails 5 Strong Parameters

### DIFF
--- a/lib/no_brainer/document/attributes.rb
+++ b/lib/no_brainer/document/attributes.rb
@@ -70,6 +70,9 @@ module NoBrainer::Document::Attributes
   end
 
   def assign_attributes(attrs, options={})
+    if NoBrainer.rails5?
+      attrs = attrs.to_h if !attrs.is_a?(Hash) && attrs.respond_to?(:to_h)
+    end
     raise ArgumentError, "To assign attributes, please pass a hash instead of `#{attrs.class}'" unless attrs.is_a?(Hash)
 
     if options[:pristine]


### PR DESCRIPTION
Strong parameters are not a Hash anymore in Rails 5, but support
transforming into a hash. Fixes #211.