### PR TITLE
Add support for username and password authentication

### DIFF
--- a/lib/no_brainer/connection.rb
+++ b/lib/no_brainer/connection.rb
@@ -18,11 +18,19 @@ class NoBrainer::Connection
           "Invalid URI. Expecting something like rethinkdb://host:port/database. Got #{uri}"
       end
 
-      { :auth_key => uri.password,
+      auth = {
         :host     => uri.host,
         :port     => uri.port || 28015,
-        :db       => uri.path.gsub(/^\//, ''),
-      }.tap { |result| raise "No database specified in #{uri}" unless result[:db].present? }
+        :db       => uri.path.gsub(/^\//, '')
+      }
+
+      if uri.user.present?
+        auth.merge! :user => uri.user, :password => uri.password
+      else
+        auth.merge! :auth_key => uri.password
+      end
+
+      auth.tap { |result| raise "No database specified in #{uri}" unless result[:db].present? }
     end
   end
 

--- a/spec/integration/connection_spec.rb
+++ b/spec/integration/connection_spec.rb
@@ -26,6 +26,22 @@ unless ENV['EM']
   end
 end
 
+describe 'NoBrainer::Connection.parse_uri' do
+  let(:connection) { NoBrainer::Connection.new }
+  let(:auth_key) { 'rethinkdb://:abcd@localhost:1234/db' }
+  let(:user) { 'rethinkdb://user:pass@localhost:1234/db' }
+
+  it 'parses token auth' do
+    connection = NoBrainer::Connection.new(auth_key)
+    expect(connection.parsed_uri[:auth_key]).to eq('abcd')
+  end
+
+  it 'parses user auth' do
+    connection = NoBrainer::Connection.new(user)
+    expect(connection.parsed_uri.slice(:user, :password).values).to eq(['user', 'pass'])
+  end
+end
+
 describe 'NoBrainer.run' do
   it 'works well' do
     NoBrainer.run { |r| r.expr(3) }.should == 3


### PR DESCRIPTION
Fixes #200, and maintains support for auth keys. Also added tests for parsing URIs with and without usernames.