### PR TITLE
Changes lock key type from string to text

### DIFF
--- a/lib/no_brainer/lock.rb
+++ b/lib/no_brainer/lock.rb
@@ -8,7 +8,7 @@ class NoBrainer::Lock
   # Since PKs are limited to 127 characters, we can't use the user's key as a PK
   # as it could be arbitrarily long.
   field :key_hash,       :type => String, :primary_key => true, :default => ->{ Digest::SHA1.base64digest(key.to_s) }
-  field :key,            :type => String
+  field :key,            :type => Text
   field :instance_token, :type => String, :default => ->{ get_new_instance_token }
   field :expires_at,     :type => Time
 


### PR DESCRIPTION
To support more than 255 characters by default, the key type needs to be Text.

I was getting a ArgumentError obtaining the lock because one of the uniqueness fields was a long text field.