### PR TITLE
Implements migration scripts

### DIFF
--- a/gemfiles/rails4.gemfile
+++ b/gemfiles/rails4.gemfile
@@ -8,6 +8,8 @@ gem 'eventmachine' if ENV['EM']
 gem "activesupport", "< 5.0.0"
 gem "activemodel",   "< 5.0.0"
 
+gem 'generator_spec'
+
 group :development do
   gem 'pry'
   gem 'simplecov', :require => false

--- a/gemfiles/rails5.gemfile
+++ b/gemfiles/rails5.gemfile
@@ -8,6 +8,8 @@ gem 'eventmachine' if ENV['EM']
 gem "activesupport",     "< 6"
 gem "activemodel",       "< 6"
 
+gem 'generator_spec'
+
 group :development do
   gem 'pry'
   gem 'simplecov', :require => false

--- a/gemfiles/rails6.gemfile
+++ b/gemfiles/rails6.gemfile
@@ -8,8 +8,10 @@ gem 'eventmachine' if ENV['EM']
 gem "activesupport",     ">= 6.0.0"
 gem "activemodel",       ">= 6.0.0"
 
+gem 'generator_spec'
+
 group :development do
-  gem 'pry'
   gem 'awesome_print', :require => false
+  gem 'pry'
   gem 'simplecov', :require => false
 end

--- a/lib/no_brainer/error.rb
+++ b/lib/no_brainer/error.rb
@@ -14,6 +14,7 @@ module NoBrainer::Error
   class LockInvalidOp           < RuntimeError; end
   class LockUnavailable         < RuntimeError; end
   class InvalidPolymorphicType  < RuntimeError; end
+  class MigrationFailure        < RuntimeError; end
 
   class DocumentInvalid < RuntimeError
     attr_accessor :instance

--- a/lib/no_brainer/migration.rb
+++ b/lib/no_brainer/migration.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module NoBrainer
+  #
+  # Parent class of all migration scripts.
+  # This class is used by the NoBrainer::Migrator class.
+  #
+  class Migration
+    class NoImplementedError < StandardError; end
+
+    def migrate!
+      up
+    rescue StandardError
+      raise unless respond_to?(:down)
+
+      begin
+        down
+        raise
+      rescue StandardError
+        raise
+      end
+    end
+
+    def rollback!
+      down if respond_to?(:down)
+    rescue StandardError
+      raise
+    end
+
+    def up
+      raise NoImplementedError
+    end
+  end
+end

--- a/lib/no_brainer/migrator.rb
+++ b/lib/no_brainer/migrator.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+module NoBrainer
+  #
+  # The Migrator class is used in order to execute a migration script and store
+  # the migration script "version" or timestap in a table allowing to run it
+  # only once.
+  # The mechanism is heavily inspired by the ActiveRecord one.
+  #
+  # It supports both migrate and rollback.
+  #
+  class Migrator
+    def self.migrations_table_name
+      'nobrainer_migration_versions'
+    end
+
+    def initialize(path)
+      @path = path
+      @version, snake_class_name = path.scan(%r{^.*/(\d+)_(.*)\.rb}).flatten
+
+      @name = snake_class_name ? snake_class_name.camelize : nil
+    end
+
+    def migrate
+      return if version_exists?
+
+      require @path
+
+      announce 'migrating'
+
+      time = Benchmark.measure do
+        migration_script = @name.constantize.new
+        migration_script.migrate!
+      end
+
+      announce 'migrated (%.4fs)' % time.real
+
+      create_version!
+    end
+
+    def rollback
+      return unless version_exists?
+
+      announce 'reverting'
+
+      require @path
+
+      time = Benchmark.measure do
+        migration_script = @name.constantize.new
+        migration_script.rollback!
+      end
+
+      announce 'reverted (%.4fs)' % time.real
+
+      remove_version!
+    end
+
+    private
+
+    # Stollen from the ActiveRecord gem
+    def announce(message)
+      text = "#{@version} #{@name}: #{message}"
+      length = [0, 75 - text.length].max
+      puts "== #{text} #{'=' * length}"
+    end
+
+    def check_if_version_exists?
+      NoBrainer.run do |r|
+        r.table(self.class.migrations_table_name).filter({ version: @version })
+      end.first.present?
+    end
+
+    def create_migrations_table_if_needed!
+      return if migrations_table_exists?
+
+      create_migrations_table!
+    end
+
+    def create_migrations_table!
+      result = NoBrainer.run do |r|
+        r.table_create(self.class.migrations_table_name)
+      end
+
+      return if result['tables_created'] == 1
+
+      raise NoBrainer::Error::MigrationFailure,
+            'Something prevented from creating the ' \
+            "'#{self.class.migrations_table_name}' table."
+    end
+
+    def create_version!
+      result = NoBrainer.run do |r|
+        r.table(self.class.migrations_table_name).insert({ version: @version })
+      end
+
+      return true if result['inserted'] == 1
+
+      raise NoBrainer::Error::MigrationFailure,
+            "Something prevented from inserting the version '#{@version}'"
+    end
+
+    def migrations_table_exists?
+      NoBrainer.run(&:table_list).include?(self.class.migrations_table_name)
+    end
+
+    def remove_version!
+      result = NoBrainer.run do |r|
+        r.table(self.class.migrations_table_name)
+         .filter({ version: @version })
+         .delete
+      end
+
+      return true if result['deleted'] == 1
+
+      raise NoBrainer::Error::MigrationFailure,
+            "Something prevented from deleting the version '#{@version}'"
+    end
+
+    def version_exists?
+      create_migrations_table_if_needed!
+
+      check_if_version_exists?
+    end
+  end
+end

--- a/lib/nobrainer.rb
+++ b/lib/nobrainer.rb
@@ -16,7 +16,8 @@ module NoBrainer
   # Code that is loaded through the DSL of NoBrainer should not be eager loaded.
   autoload :Document, :IndexManager, :Loader, :Fork, :Geo, :SymbolDecoration
   eager_autoload :Config, :Connection, :ConnectionManager, :Error,
-                 :QueryRunner, :Criteria, :RQL, :Lock, :ReentrantLock, :Profiler, :System
+                 :QueryRunner, :Criteria, :RQL, :Lock, :ReentrantLock, :Profiler,
+                 :System, :Migrator, :Migration
 
   class << self
     delegate :connection, :disconnect, :to => 'NoBrainer::ConnectionManager'

--- a/lib/rails/generators/nobrainer/migration_generator.rb
+++ b/lib/rails/generators/nobrainer/migration_generator.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails/generators/nobrainer/namespace_fix'
+require 'rails/generators/named_base'
+
+module NoBrainer
+  module Generators
+    #
+    # Generates a migration script prefixed with the date and time of
+    # its creation.
+    #
+    class MigrationGenerator < Rails::Generators::NamedBase
+      extend NoBrainer::Generators::NamespaceFix
+      source_root File.expand_path('../templates', __dir__)
+
+      desc 'Generates a new migration script in ./db/migrate/'
+
+      check_class_collision
+
+      def create_model_file
+        template 'migration.rb', File.join('db', 'migrate', timestamped_filename)
+      end
+
+      hook_for :test_framework
+
+      def timestamped_filename
+        "#{Time.current.strftime('%Y%m%d%H%M%S')}_#{file_name}.rb"
+      end
+    end
+  end
+end

--- a/lib/rails/generators/templates/migration.rb
+++ b/lib/rails/generators/templates/migration.rb
@@ -1,0 +1,7 @@
+class <%= class_name %> < NoBrainer::Migration
+  def up
+  end
+
+  def down
+  end
+end

--- a/spec/integration/migration_scripts_spec.rb
+++ b/spec/integration/migration_scripts_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe NoBrainer::Migrator do
+  let(:a_script_path) do
+    File.join(File.expand_path('../tmp', __dir__), 'db', 'migrate',
+              "#{Time.current.strftime('%Y%m%d%H%M%S')}_my_migration.rb")
+  end
+  let(:migrations_table_name) { NoBrainer::Migrator.migrations_table_name }
+  let(:table_list) { NoBrainer.run(&:table_list) }
+  let(:script_content) do
+    <<-SCRIPT
+    class MyMigration < NoBrainer::Migration
+      def up
+      end
+
+      def down
+      end
+    end
+    SCRIPT
+  end
+
+  before do
+    FileUtils.mkdir_p(File.dirname(a_script_path))
+    File.open(a_script_path, 'w') { |file| file.write(script_content) }
+
+    # Prevents outputs
+    allow_any_instance_of(described_class)
+      .to receive(:announce).and_return(true)
+  end
+
+  context 'on first run' do
+    context 'when running migrate' do
+      before { described_class.new(a_script_path).migrate }
+
+      it 'create the migrations table' do
+        expect(table_list).to include migrations_table_name
+      end
+    end
+
+    context 'when running rollback' do
+      before { described_class.new(a_script_path).migrate }
+
+      it 'create the migrations table' do
+        expect(table_list).to include migrations_table_name
+      end
+    end
+  end
+
+  describe 'migrate' do
+    let(:migrator) { described_class.new(a_script_path) }
+
+    it 'checks the version from the migrations table' do
+      expect(migrator).to receive(:check_if_version_exists?)
+
+      migrator.migrate
+    end
+
+    it 'runs the script migrate! method' do
+      require a_script_path
+      expect_any_instance_of(MyMigration).to receive(:migrate!)
+
+      migrator.migrate
+    end
+
+    context 'when the script has failed and have a down method' do
+      before do
+        require a_script_path
+        expect_any_instance_of(MyMigration)
+          .to receive(:up).and_raise('ERROR')
+      end
+
+      it "doesn't create the version" do
+        expect(migrator).not_to receive(:create_version!)
+
+        expect { migrator.migrate }.to raise_error('ERROR')
+      end
+
+      it 'runs the down method then raise the error' do
+        expect_any_instance_of(MyMigration).to receive(:down)
+
+        expect { migrator.migrate }.to raise_error('ERROR')
+      end
+    end
+
+    context 'when the script has failed but do not have a down method' do
+      before do
+        require a_script_path
+        allow_any_instance_of(MyMigration)
+          .to receive(:respond_to?).with(:down).and_return(false)
+        expect_any_instance_of(MyMigration)
+          .to receive(:up).and_raise('ERROR')
+      end
+
+      it "doesn't create the version" do
+        expect(migrator).not_to receive(:create_version!)
+
+        expect { migrator.migrate }.to raise_error('ERROR')
+      end
+
+      it "doesn't run the down method but raises the error" do
+        expect_any_instance_of(MyMigration).not_to receive(:down)
+
+        expect { migrator.migrate }.to raise_error('ERROR')
+      end
+    end
+
+    context 'when the script has succeeded' do
+      before { require a_script_path }
+      it 'runs the up method' do
+        expect_any_instance_of(MyMigration).to receive(:up)
+
+        migrator.migrate
+      end
+
+      it "doesn't run the down method" do
+        expect_any_instance_of(MyMigration).not_to receive(:down)
+
+        migrator.migrate
+      end
+
+      it 'creates the version' do
+        expect(migrator).to receive(:create_version!)
+
+        migrator.migrate
+      end
+    end
+
+    context 'when executed twice' do
+      before do
+        allow(migrator).to receive(:check_if_version_exists?).and_return(true)
+      end
+
+      it "doesn't run the up method" do
+        expect_any_instance_of(MyMigration).not_to receive(:up)
+
+        migrator.migrate
+      end
+    end
+  end
+
+  describe 'rollback' do
+    let(:migrator) { described_class.new(a_script_path) }
+
+    context 'when the migration script has not being migrated yet' do
+      it "doesn't run the script rollback! method" do
+        require a_script_path
+        expect_any_instance_of(MyMigration).not_to receive(:rollback!)
+
+        migrator.rollback
+      end
+    end
+
+    context 'when the migration script has not being migrated yet' do
+      before { migrator.migrate }
+
+      it 'checks the version from the migrations table' do
+        expect(migrator).to receive(:check_if_version_exists?)
+
+        migrator.rollback
+      end
+
+      it 'runs the script rollback! method' do
+        require a_script_path
+        expect_any_instance_of(MyMigration).to receive(:rollback!)
+
+        migrator.rollback
+      end
+
+      context 'when the script do not have a down method' do
+        before do
+          require a_script_path
+          allow_any_instance_of(MyMigration)
+            .to receive(:respond_to?).with(:down).and_return(false)
+        end
+
+        it 'removes the version' do
+          expect(migrator).to receive(:remove_version!)
+
+          migrator.rollback
+        end
+      end
+
+      context 'when the script has a down method which fails' do
+        before do
+          require a_script_path
+          allow_any_instance_of(MyMigration)
+            .to receive(:down).and_raise('ERROR')
+        end
+
+        it 'runs the down method' do
+          expect_any_instance_of(MyMigration).to receive(:down)
+
+          expect { migrator.rollback }.to raise_error('ERROR')
+        end
+
+        it "doesn't remove the version but raise the error" do
+          expect(migrator).not_to receive(:remove_version!)
+
+          expect { migrator.rollback }.to raise_error('ERROR')
+        end
+      end
+
+      context 'when the script has a down method which succeeded' do
+        before do
+          require a_script_path
+        end
+
+        it 'runs the down method' do
+          expect_any_instance_of(MyMigration).to receive(:down)
+
+          migrator.rollback
+        end
+
+        it 'removes the version but raise the error' do
+          expect(migrator).to receive(:remove_version!)
+
+          migrator.rollback
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/generators/migration_generator_spec.rb
+++ b/spec/lib/generators/migration_generator_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'generator_spec'
+require 'rails/generators/nobrainer/migration_generator'
+
+describe NoBrainer::Generators::MigrationGenerator do
+  SCRIPT_NAME = 'MigrateMyBeautifulDataNow'
+
+  destination File.expand_path('../tmp', __dir__)
+  arguments [SCRIPT_NAME]
+
+  let(:formatted_time) { time_current.strftime('%Y%m%d%H%M%S') }
+  let(:snake_case_script_name) { SCRIPT_NAME.underscore }
+  let(:time_current) { Time.current }
+
+  before do
+    allow(Time).to receive(:current).and_return(time_current)
+
+    prepare_destination
+    run_generator
+  end
+
+  it 'creates a new file in the db/migrate' do
+    assert_file "db/migrate/#{formatted_time}_#{snake_case_script_name}.rb",
+                <<-SCRIPT
+class #{SCRIPT_NAME} < NoBrainer::Migration
+  def up
+  end
+
+  def down
+  end
+end
+SCRIPT
+  end
+end


### PR DESCRIPTION
This PR adds support for migration scripts with nobrainer, heavily inspired from the ActiveRecord Migration Script concept (meaning familiar to RoR people that we are).

Migration script is really helpful in the data migration concern. Fix wrongly created data, deleting old data and more, can be easily done with migration scripts.
It is especially true as I've implemented the Capistrano integration too, exactly as AR is doing.

I've added a very basic generator which generates a migration script file named the same way as AR does. The migration scripts are inheriting from the new `NoBrainer::Migration` class which holds the logic of running `up` then `down` if `up` failed.

Finally the new `NoBrainer::Migrator` class contains the heart of this PR and take care of:
* creating a table to store the script versions (well its timestamp, like AR does) to run the script only once
* run in a `Benchmark.measure` block the migration script and shows the execution time (I've stoled the `announce` method from ActiveRecord)
* save or delete the script version

The migrator supports both migrating all non executed scripts, and rollbacking the last script only.

So it's a very minimal implementation with tests everywhere AFAIK.

I'm using this branch for a production project at work and it works pretty well. I really hope you'll accept it 🙏. I'm of course ready to fix all the things that would need it.