### PR TITLE
Fixes for Rails v7.1+

### DIFF
--- a/lib/no_brainer/autoload.rb
+++ b/lib/no_brainer/autoload.rb
@@ -14,9 +14,17 @@ module NoBrainer::Autoload
   end
 
   def eager_load!
-    super
-    @_autoloads.keys.map  { |c| const_get(c) }
-                    .each { |c| c.eager_load! if c.respond_to?(:eager_load!) }
+    if NoBrainer.rails71?
+      if @_eagerloaded_constants
+        @_eagerloaded_constants.map { |const_name| const_get(const_name) }
+                               .each { |c| c.eager_load! if c.respond_to?(:eager_load!) }
+        @_eagerloaded_constants = nil
+      end
+    else
+      super
+      @_autoloads.keys.map  { |c| const_get(c) }
+                      .each { |c| c.eager_load! if c.respond_to?(:eager_load!) }
+    end
   end
 
   def autoload_and_include(*constants)

--- a/lib/no_brainer/railtie.rb
+++ b/lib/no_brainer/railtie.rb
@@ -21,7 +21,11 @@ class NoBrainer::Railtie < Rails::Railtie
     # Not the cleanest behavior, but if ActiveRecord does it, why not.
     unless defined?(ActiveRecord)
       console = ActiveSupport::Logger.new(STDERR)
-      Rails.logger.extend ActiveSupport::Logger.broadcast(console)
+      if NoBrainer.rails71?
+        Rails.logger.broadcast_to(console)
+      else
+        Rails.logger.extend ActiveSupport::Logger.broadcast(console)
+      end
     end
   end
 

--- a/lib/nobrainer.rb
+++ b/lib/nobrainer.rb
@@ -56,6 +56,10 @@ module NoBrainer
       Gem.loaded_specs['activesupport'].version >= Gem::Version.new('6.0.0')
     end
 
+    def rails71?
+      Gem.loaded_specs['activesupport'].version >= Gem::Version.new('7.1.0')
+    end
+
     def eager_load!
       # XXX This forces all the NoBrainer code to be loaded in memory.
       # Not to be confused with eager_load() that operates on documents.


### PR DESCRIPTION
Finally got around to upgrading some of my Rails apps to v7.1 and hit a couple of issues where NoBrainer code was copied from ActiveRecord.

* Added convenience method for checking Rails version >= 7.1
* Fix for autoload
* Fix for logging in console

Not really sure how to test these, probably add a Rails 7.1 entry to the CI matrix.