### PR TITLE
Deprecates ruby 1.9 (Closes #290)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ require:
 
 AllCops:
   NewCops: enable
+  TargetRubyVersion: 2.2
 
 Metrics/BlockLength:
   IgnoredMethods: ['describe', 'context']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Ruby 3 support
 - RSPEC_SEED earthly ARG to replay an Rspec seed
+- Ruby 1.9.0 deprecation
 
 ### Changed
 - docker compose file for Earthly in order to give a project name

--- a/Gemfile.ci_tools
+++ b/Gemfile.ci_tools
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 gem 'eventmachine' if ENV['EM'] == 'true'
-gem 'rspec', '~> 3.10'
+gem 'rspec', '~> 3.13'
 gem 'rspec-instafail'
 gem 'rspec-rebound'
 gem 'timecop'

--- a/lib/no_brainer/deprecations.rb
+++ b/lib/no_brainer/deprecations.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module NoBrainer
+  module Deprecations
+    MIN_SUPPORTED_RUBY_VERSION = '2.2.0'
+
+    def self.check
+      return if RUBY_VERSION >= MIN_SUPPORTED_RUBY_VERSION
+
+      # Ruby 2.2 doesn't support heredoc like:
+      # <<~MSG.split.join(' ')
+      #  Using ruby #{RUBY_VERSION} with the nobrainer gem is deprecated.
+      #  Ruby #{MIN_SUPPORTED_RUBY_VERSION} or higher will be required to use
+      #  this gem in future versions.
+      # MSG
+      NoBrainer.logger.warn(
+        "Using ruby #{RUBY_VERSION} with the nobrainer gem is deprecated. " \
+        "Ruby #{MIN_SUPPORTED_RUBY_VERSION} or higher will be required to " \
+        'use this gem future versions.'
+      )
+    end
+  end
+end

--- a/lib/nobrainer.rb
+++ b/lib/nobrainer.rb
@@ -20,9 +20,10 @@ module NoBrainer
 
   # We eager load things that could be loaded when handling the first web request.
   # Code that is loaded through the DSL of NoBrainer should not be eager loaded.
-  autoload :Document, :IndexManager, :Loader, :Fork, :Geo, :SymbolDecoration
-  eager_autoload :Config, :Connection, :ConnectionManager, :Error,
-                 :QueryRunner, :Criteria, :RQL, :Lock, :ReentrantLock, :Profiler, :System
+  autoload :Document, :IndexManager, :Loader, :Fork, :Geo, :SymbolDecoration,
+           :Deprecations
+  eager_autoload :Config, :Connection, :ConnectionManager, :Error, :QueryRunner,
+                 :Criteria, :RQL, :Lock, :ReentrantLock, :Profiler, :System
 
   class << self
     delegate :connection, :disconnect, :to => 'NoBrainer::ConnectionManager'

--- a/nobrainer.gemspec
+++ b/nobrainer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
                   'on top of RethinkDB while providing precise semantics.'
   s.license     = 'LGPL-3.0-only'
 
-  s.required_ruby_version = ">= #{ENV.fetch('EARTHLY_RUBY_VERSION', '1.9.0')}"
+  s.required_ruby_version = ">= #{ENV.fetch('EARTHLY_RUBY_VERSION', '2.2.0')}"
 
   s.metadata['allowed_push_host'] = 'https://rubygems.org'
   s.metadata['homepage_uri'] = s.homepage

--- a/spec/integration/deprecations_spec.rb
+++ b/spec/integration/deprecations_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe NoBrainer::Deprecations do # rubocop:disable RSpec/SpecFilePathFormat
+  before { allow(NoBrainer.logger).to receive(:warn).and_call_original }
+
+  %w[1.8.7 1.9.0 2.1.0].each do |ruby_version|
+    describe "#check#{ruby_version}" do
+      before do
+        stub_const('RUBY_VERSION', ruby_version)
+        described_class.check
+      end
+
+      it 'does warn' do
+        expect(NoBrainer.logger)
+          .to have_received(:warn).with(
+            /Using ruby #{ruby_version} with the nobrainer gem is deprecated./
+          )
+      end
+    end
+  end
+
+  %w[2.2.0 2.3.0 2.6.0 2.7.2 3.0.7 3.1.0 3.4.2].each do |ruby_version|
+    describe "#check#{ruby_version}" do
+      before do
+        stub_const('RUBY_VERSION', ruby_version)
+        described_class.check
+      end
+
+      it 'does not warn' do
+        expect(NoBrainer.logger)
+          .not_to have_received(:warn)
+      end
+    end
+  end
+end

--- a/spec/integration/lock_spec.rb
+++ b/spec/integration/lock_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe NoBrainer::Lock do
+describe NoBrainer::Lock do # rubocop:disable RSpec/SpecFilePathFormat
   let(:lock1) { described_class.new(:some_key) }
   let(:lock2) { described_class.new(:some_key) }
 

--- a/spec/integration/reentrant_lock_spec.rb
+++ b/spec/integration/reentrant_lock_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe NoBrainer::ReentrantLock do
+describe NoBrainer::ReentrantLock do # rubocop:disable RSpec/SpecFilePathFormat
   let(:lock1)  { lock1a }
   let(:lock1a) { described_class.new(:some_key, :instance_token => 'hello') }
   let(:lock1b) { described_class.new(:some_key, :instance_token => 'hello') }


### PR DESCRIPTION
This PR adds warning message when the ruby version is lower than 2.2.0.